### PR TITLE
Corrige tratamento do cid10 em read.parameters

### DIFF
--- a/R/utility_tools.R
+++ b/R/utility_tools.R
@@ -603,6 +603,13 @@ read.parameters<-function(cities, cid10 = "A90", datasource=con){
         cid10 <- "A90"
       }
 
+      
+      # regra específica: Espírito Santo (só tem parâmetros de dengue)
+      if(any(grepl("^32", cities)) && cid10 != "A90") {
+        warning("Parameters for Espírito Santo are only available for dengue (A90). Using A90.")
+        cid10 <- "A90"
+      }
+      
       # reading parameters from database
       
       sqlcity = paste("'", str_c(cities, collapse = "','"),"'", sep="")

--- a/R/utility_tools.R
+++ b/R/utility_tools.R
@@ -598,14 +598,17 @@ write_parameters<-function(city, cid10, params, overwrite = FALSE, datasource = 
 read.parameters<-function(cities, cid10 = "A90", datasource=con){
       
       cities <- sapply(cities, function(x) sevendigitgeocode(x))
-      if(cid10 != "A90")print("tab de parametros so tem dengue. Usando-os.")
-      cid10 = "A90"
+      if(!cid10 %in% c("A90", "A92.0")) {
+        warning("Parameter table currently supports only A90 (dengue) and A92.0 (chikungunya). Using dengue parameters (A90).")
+        cid10 <- "A90"
+      }
+
       # reading parameters from database
       
       sqlcity = paste("'", str_c(cities, collapse = "','"),"'", sep="")
       
       if(class(datasource) == "PostgreSQLConnection"){
-      comando = paste("SELECT * FROM \"Dengue_global\".parameters WHERE cid10 = '", cid10 , 
+        comando = paste("SELECT * FROM \"Dengue_global\".parameters WHERE cid10 = '", cid10 , 
                         "' AND municipio_geocodigo  IN (", sqlcity,")", sep="")
       }
       


### PR DESCRIPTION
Closes #16 

@eduardocorrearaujo para revisão e aprovação quando possível

## Descrição

A função `read.parameters()` sobrescrevia o argumento `cid10` para `"A90"`, fazendo com que sempre fossem utilizados parâmetros de dengue, mesmo quando informado outro CID.

## Alterações

- removido o overwrite fixo de `cid10 <- "A90"`
- mantido suporte para `A90` (dengue) e `A92.0` (chikungunya)
- adicionado `warning()` com fallback para `A90` quando o CID não estiver entre dengue e chik

Teste:
``` 
> read.parameters(cities = 2611606, cid10 = "A90")
  municipio_geocodigo limiar_preseason limiar_posseason limiar_epidemico   varcli clicrit cid10 codmodelo
1             2611606         6.179298         8.149809         26.91916 temp_min      23   A90        Af
  varcli2 clicrit2 codigo_estacao_wu estacao_wu_sec
1    <NA>       NA              SBRF           SBJP
> read.parameters(cities = 2611606, cid10 = "A92.0")
  municipio_geocodigo limiar_preseason limiar_posseason limiar_epidemico   varcli clicrit cid10 codmodelo
1             2611606         2.266721         4.053523         16.64764 temp_min      23 A92.0        Af
  varcli2 clicrit2 codigo_estacao_wu estacao_wu_sec
1    <NA>       NA              SBRF           SBJP
> read.parameters(cities = 2611606, cid10 = "A92.8")
  municipio_geocodigo limiar_preseason limiar_posseason limiar_epidemico   varcli clicrit cid10 codmodelo
1             2611606         6.179298         8.149809         26.91916 temp_min      23   A90        Af
  varcli2 clicrit2 codigo_estacao_wu estacao_wu_sec
1    <NA>       NA              SBRF           SBJP
Warning message:
In read.parameters(cities = 2611606, cid10 = "A92.8") :
  Parameter table currently supports only A90 (dengue) and A92.0 (chikungunya). Using dengue parameters (A90).``` 